### PR TITLE
Linter errors were: Always tag the version of an image explicitly, an…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM registry.access.redhat.com/ubi8/nodejs-10
+FROM registry.access.redhat.com/ubi8/nodejs-10:1
 
 RUN mkdir app
 
 # Install npm production packages
 COPY package.json ./app
-RUN cd ./app; npm install --production
+WORKDIR /app
 
-COPY . ./app
+RUN npm install --production
+
+COPY . .
 
 ENV NODE_ENV production
 ENV PORT 3000
 
 EXPOSE 3000
-
-WORKDIR ./app
 
 CMD ["npm", "start"]


### PR DESCRIPTION
Per hadolint comments, instead of RUN cd <foldername> use WORKDIR to switch to a directory, also no need to use WORKDIR right before CMD command because we already assigned WORKDIR